### PR TITLE
Allow a different format for the config files between Galaxy and uwsgi

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ galaxy_zergpool_socket_name: zergpool.sock
 galaxy_zergpool_listen_path: "{{ galaxy_mutable_data_dir }}/{{ galaxy_zergpool_socket_name }}"
 
 galaxy_systemd_zergling_uwsgi_config_style: "{{ galaxy_config_style | default('ini')}}"
-galaxy_systemd_zergling_uwsgi_config_file: "{{ galaxy_config_dir }}/uwsgi.ini"
+galaxy_systemd_zergling_uwsgi_config_file: "{{ galaxy_config_file }}"
 
 # Any extra env vars you wish to set for Zerglings OR Mules (anything that runs web)
 galaxy_systemd_zergling_env: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ galaxy_zergpool_socket_name: zergpool.sock
 # Where the socket for the zergling will be placed
 galaxy_zergpool_listen_path: "{{ galaxy_mutable_data_dir }}/{{ galaxy_zergpool_socket_name }}"
 
+galaxy_systemd_zergling_uwsgi_config_style: "{{ galaxy_config_style | default('ini')}}"
+galaxy_systemd_zergling_uwsgi_config_file: "{{ galaxy_config_dir }}/uwsgi.ini"
+
 # Any extra env vars you wish to set for Zerglings OR Mules (anything that runs web)
 galaxy_systemd_zergling_env: ""
 # Any extra env vars to pass to the handlers

--- a/templates/galaxy-zergling@.service.j2
+++ b/templates/galaxy-zergling@.service.j2
@@ -10,7 +10,7 @@ User={{ galaxy_user.name }}
 Group={{ __galaxy_user_group }}
 WorkingDirectory={{ galaxy_server_dir }}
 TimeoutStartSec=10
-ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_config_style in ('yaml', 'yml') else '--ini' }} --stats 127.0.0.1:401%I {% if galaxy_zergpool %}--zerg {{ galaxy_zergpool_listen_path }}{% else %}--socket 127.0.0.1:400%I{% endif %}
+ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_systemd_zergling_uwsgi_config_style in ('yaml', 'yml') else '--ini' }} {{ galaxy_systemd_zergling_uwsgi_config_file }} --stats 127.0.0.1:401%I {% if galaxy_zergpool %}--zerg {{ galaxy_zergpool_listen_path }}{% else %}--socket 127.0.0.1:400%I{% endif %}
 
 Environment=HOME={{ galaxy_root }} VIRTUAL_ENV={{ galaxy_venv_dir }} PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin DOCUTILSCONFIG='' PYTHONPATH={{ galaxy_dynamic_job_rules_dir }} {{ galaxy_systemd_zergling_env }}
 MemoryLimit={{ galaxy_systemd_memory_limit }}G


### PR DESCRIPTION
add a missing var and allow to use a different format for the config files between Galaxy and uwsgi