### PR TITLE
Replace service unit name with templated variable + GH Workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: ansible-lint
+on: [pull_request_target]
+jobs:
+  ansible-lint:
+    name: ansible-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: ansible-lint
+        uses: reviewdog/action-ansiblelint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: nofilter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+
+'on':
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-base
+
+      - name: Trigger a new import on Galaxy.
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch master

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ This role was written and contributed to by the following people:
 
 - [Ott Oopkaup](https://github.com/ooobik)
 - [Helena Rasche](https://github.com/erasche)
+- [Donny Vrins](https://github.com/Dirowa)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 galaxy_systemd_mode: "zerg" # alternatively "mule"
 
 #required to be changed when multiple galaxy instances run on the same server
-galaxy_systemd_sub_dest: "main"
+galaxy_systemd_unit_name: "galaxy"
 
 # Mule Options
 galaxy_systemd_memory_limit_mule: 32

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 galaxy_systemd_mode: "zerg" # alternatively "mule"
 
+#required to be changed when multiple galaxy instances run on the same server
+galaxy_systemd_sub_dest: "main"
+
 # Mule Options
 galaxy_systemd_memory_limit_mule: 32
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,14 @@
 ---
 galaxy_info:
+  role_name: galaxy_systemd
+  namespace: usegalaxy_eu
+
   author: Galaxy Europe
-  description: Manage Galaxy server(s) with systemd.
-  company: Galaxy Europe
-  license: GPL-3.0
-  min_ansible_version: 2.5
-  role_name: galaxy-systemd
+  description: Sets up SystemD for Galaxy
+  company: The Galaxy Project
+  license: GPL-3.0-or-later
+  min_ansible_version: 2.7
+  github_branch: main
   platforms:
   - name: EL
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Galaxy Europe
-  description: Manage a Galaxy server with systemd.
+  description: Manage Galaxy server(s) with systemd.
   company: Galaxy Europe
   license: GPL-3.0
   min_ansible_version: 2.5

--- a/tasks/mule.yml
+++ b/tasks/mule.yml
@@ -4,7 +4,7 @@
     group: root
     mode: 0644
     src: galaxy.service.j2
-    dest: /etc/systemd/system/galaxy.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy.service
   notify:
     - galaxy handler daemon reload
     - galaxy mule start

--- a/tasks/mule.yml
+++ b/tasks/mule.yml
@@ -4,7 +4,7 @@
     group: root
     mode: 0644
     src: galaxy.service.j2
-    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_unit_name }}.service
   notify:
     - galaxy handler daemon reload
     - galaxy mule start

--- a/tasks/zerg.yml
+++ b/tasks/zerg.yml
@@ -4,7 +4,7 @@
     group: root
     mode: 0644
     src: galaxy-zergpool.service.j2
-    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-zergpool.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_unit_name }}-zergpool.service
   when: galaxy_zergpool
   notify: galaxy handler daemon reload
 
@@ -14,7 +14,7 @@
     group: root
     mode: 0644
     src: galaxy-zergling@.service.j2
-    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-zergling@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_unit_name }}-zergling@.service
   notify: galaxy handler daemon reload
 
 - name: Deploy handler units
@@ -23,7 +23,7 @@
     group: root
     mode: 0644
     src: galaxy-handler@.service.j2
-    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-handler@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_unit_name }}-handler@.service
   notify: galaxy handler daemon reload
 
 - name: Deploy workflow units
@@ -32,7 +32,7 @@
     group: root
     mode: 0644
     src: galaxy-workflow-scheduler@.service.j2
-    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-workflow-scheduler@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_unit_name }}-workflow-scheduler@.service
   notify: galaxy workflow scheduler daemon reload
 
 # TODO: In case of changes? Not sure this is necessary.

--- a/tasks/zerg.yml
+++ b/tasks/zerg.yml
@@ -4,7 +4,7 @@
     group: root
     mode: 0644
     src: galaxy-zergpool.service.j2
-    dest: /etc/systemd/system/galaxy-zergpool.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-zergpool.service
   when: galaxy_zergpool
   notify: galaxy handler daemon reload
 
@@ -14,7 +14,7 @@
     group: root
     mode: 0644
     src: galaxy-zergling@.service.j2
-    dest: /etc/systemd/system/galaxy-zergling@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-zergling@.service
   notify: galaxy handler daemon reload
 
 - name: Deploy handler units
@@ -23,7 +23,7 @@
     group: root
     mode: 0644
     src: galaxy-handler@.service.j2
-    dest: /etc/systemd/system/galaxy-handler@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-handler@.service
   notify: galaxy handler daemon reload
 
 - name: Deploy workflow units
@@ -32,7 +32,7 @@
     group: root
     mode: 0644
     src: galaxy-workflow-scheduler@.service.j2
-    dest: /etc/systemd/system/galaxy-workflow-scheduler@.service
+    dest: /etc/systemd/system/{{ galaxy_systemd_sub_dest }}/galaxy-workflow-scheduler@.service
   notify: galaxy workflow scheduler daemon reload
 
 # TODO: In case of changes? Not sure this is necessary.

--- a/templates/galaxy-handler@.service.j2
+++ b/templates/galaxy-handler@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Handlers
+Description=Galaxy Handlers for {{galaxy_systemd_sub_dest}}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-handler@.service.j2
+++ b/templates/galaxy-handler@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Handlers for {{galaxy_systemd_sub_dest}}
+Description=Galaxy Handlers for {% if galaxy_instance_codename %} for {{ galaxy_instance_codename | default(galaxy_systemd_unit_name) }}{% endif %}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-workflow-scheduler@.service.j2
+++ b/templates/galaxy-workflow-scheduler@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Workflow Scheduler
+Description=Galaxy Workflow Scheduler for {{galaxy_systemd_sub_dest}}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-workflow-scheduler@.service.j2
+++ b/templates/galaxy-workflow-scheduler@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Workflow Scheduler for {{galaxy_systemd_sub_dest}}
+Description=Galaxy Workflow Scheduler for {% if galaxy_instance_codename %} for {{ galaxy_instance_codename | default(galaxy_systemd_unit_name) }}{% endif %}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-zergling@.service.j2
+++ b/templates/galaxy-zergling@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Zerglings
+Description=Galaxy Zerglings for {{galaxy_systemd_sub_dest}}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-zergling@.service.j2
+++ b/templates/galaxy-zergling@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Zerglings for {{galaxy_systemd_sub_dest}}
+Description=Galaxy Zerglings for {{% if galaxy_instance_codename %} for {{ galaxy_instance_codename | default(galaxy_systemd_unit_name) }}{% endif %}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-zergpool.service.j2
+++ b/templates/galaxy-zergpool.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Zergpool
+Description=Galaxy Zergpool for {{galaxy_systemd_sub_dest}}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy-zergpool.service.j2
+++ b/templates/galaxy-zergpool.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy Zergpool for {{galaxy_systemd_sub_dest}}
+Description=Galaxy Zergpool for {% if galaxy_instance_codename %} for {{ galaxy_instance_codename | default(galaxy_systemd_unit_name) }}{% endif %}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy.service.j2
+++ b/templates/galaxy.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy
+Description=Galaxy for {{galaxy_systemd_sub_dest}}
 After=network.target
 After=time-sync.target
 

--- a/templates/galaxy.service.j2
+++ b/templates/galaxy.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Galaxy for {{galaxy_systemd_sub_dest}}
+Description=Galaxy for {% if galaxy_instance_codename %} for {{ galaxy_instance_codename | default(galaxy_systemd_unit_name) }}{% endif %}
 After=network.target
 After=time-sync.target
 


### PR DESCRIPTION
This replaces the service unit name (galaxy) with a templated variable, we need this to run two co-existent galaxy servers on the same machine.

I've also added the github workflows for linting since those are working out well over in galaxyproject! If you setup the secrets you can just tag things via git or github and the release will be done automatically.