### PR TITLE
add workflow_scheduler prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sets up Galaxy server processes responsible for:
 
 ## Major Changes
 
+- Workflow Schedulers now have a scalable prefix, too. `galaxy_systemd_workflow_scheduler_prefix` By default the first part of `ansible_hostname`
 - Handlers have a `galaxy_systemd_handler_prefix` var now, which should be used to give them a unique key together with their process number. For example by using the hostname as prefix, like in the [deafults][defaults]. This makes an **update of the job_conf necessary**.
 - Gunicorn is now scalable: just define a number in `galaxy_systemd_gunicorns` and like the handlers, that many of them will spawn.
 - The Socket name should now be without the '.sock' prefix, as the sockets are automatically created for each Gunicorn process.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Sets up Galaxy server processes responsible for:
 
 ## Major Changes
 
+:warning: **You need to reassign jobs to the newly named handlers/workflow schedulers, for example with:**
+
+```sh
+mutate reassign-job-to-handler <job_id> <handler_id> [--commit]
+```
+
+and with for loop for example like this (be careful with mutate, no warranties):
+
+```bash
+for job in $(gxadmin query queue-details | awk '/handler_key_0/ {print $3}'); do gxadmin mutate reassign-job-to-handler $job handler_sn06_0 --commit; done
+
+```
+
 - Workflow Schedulers now have a scalable prefix, too. `galaxy_systemd_workflow_scheduler_prefix` By default the first part of `ansible_hostname`
 - Handlers have a `galaxy_systemd_handler_prefix` var now, which should be used to give them a unique key together with their process number. For example by using the hostname as prefix, like in the [deafults][defaults]. This makes an **update of the job_conf necessary**.
 - Gunicorn is now scalable: just define a number in `galaxy_systemd_gunicorns` and like the handlers, that many of them will spawn.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ galaxy_systemd_mode: "zerg"
 galaxy_systemd_handler_prefix: "handler_{{  ansible_hostname.split('.')[0] | lower }}"
 galaxy_systemd_handlers: 12
 galaxy_systemd_workflow_schedulers: 0
+galaxy_systemd_workflow_scheduler_prefix: "workflow_scheduler_{{  ansible_hostname.split('.')[0] | lower }}"
 
 # Maximum memory limits (in GB) are set for every process in their systemd unit file, and applied through cgroups.
 galaxy_systemd_memory_limit: 16

--- a/templates/galaxy-workflow-scheduler@.service.j2
+++ b/templates/galaxy-workflow-scheduler@.service.j2
@@ -10,7 +10,7 @@ User={{ galaxy_user.name }}
 Group={{ __galaxy_user_group }}
 WorkingDirectory={{ galaxy_server_dir }}
 TimeoutStartSec=30
-ExecStart={{ galaxy_venv_dir }}/bin/python ./scripts/galaxy-main -c {{ galaxy_config_dir }}/{{ galaxy_config_file_basename }} --server-name=workflow_scheduler_{{ galaxy_instance_codename }}_%I
+ExecStart={{ galaxy_venv_dir }}/bin/python ./scripts/galaxy-main -c {{ galaxy_config_dir }}/{{ galaxy_config_file_basename }} --server-name={{ galaxy_systemd_workflow_scheduler_prefix }}_%I
 Environment=HOME={{ galaxy_root }} VIRTUAL_ENV={{ galaxy_venv_dir }} PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin DOCUTILSCONFIG='' PYTHONPATH={{ galaxy_dynamic_job_rules_dir }} {{ galaxy_systemd_workflow_scheduler_env }}
 MemoryLimit={{ galaxy_systemd_memory_limit_workflow }}G
 Restart=always


### PR DESCRIPTION
Added a prefix variable for the workflow_scheduler server name, which is by default the first part of `ansible_hostname`, like in the handlers template.