### PR TITLE
add gunicorn max-requests and max-requests-jitter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,12 @@ galaxy_systemd_gunicorn_timeout: 300
 galaxy_systemd_gunicorn_socket_name: gunicorn
 galaxy_systemd_gunicorn_listen_path: "{{ galaxy_mutable_data_dir }}/{{ galaxy_systemd_gunicorn_socket_name }}"
 
+# The maximum number of requests a worker will process before restarting.
+galaxy_systemd_gunicorn_max_requests: 0
+
+# The maximum jitter to add to the max_requests setting.
+galaxy_systemd_gunicorn_max_requests_jitter: 0
+
 # Any extra env vars you wish to set for Gunicorn
 galaxy_systemd_gunicorn_env: ""
 # uncomment this if yuo want to disable the preload option

--- a/templates/galaxy-gunicorn@.service.j2
+++ b/templates/galaxy-gunicorn@.service.j2
@@ -11,7 +11,7 @@ Group={{ __galaxy_user_group }}
 WorkingDirectory={{ galaxy_server_dir }}
 TimeoutStartSec=10
 {% set _gunicorn_preload = galaxy_systemd_gunicorn_preload | default(galaxy_systemd_gunicorn_preload_default) -%}
-ExecStart={{ galaxy_venv_dir }}/bin/gunicorn 'galaxy.webapps.galaxy.fast_factory:factory()' --timeout {{ galaxy_systemd_gunicorn_timeout }} --pythonpath lib -k galaxy.webapps.galaxy.workers.Worker -b unix:{{ galaxy_systemd_gunicorn_listen_path }}_%I.sock --workers={{ galaxy_systemd_gunicorn_workers }} --config python:galaxy.web_stack.gunicorn_config {{ _gunicorn_preload }} --forwarded-allow-ips="*"
+ExecStart={{ galaxy_venv_dir }}/bin/gunicorn 'galaxy.webapps.galaxy.fast_factory:factory()' --timeout {{ galaxy_systemd_gunicorn_timeout }} --pythonpath lib -k galaxy.webapps.galaxy.workers.Worker -b unix:{{ galaxy_systemd_gunicorn_listen_path }}_%I.sock --workers={{ galaxy_systemd_gunicorn_workers }} --config python:galaxy.web_stack.gunicorn_config {{ _gunicorn_preload }} --forwarded-allow-ips="*" --max-requests {{ galaxy_systemd_gunicorn_max_requests }} --max-requests-jitter {{ galaxy_systemd_gunicorn_max_requests_jitter }}
 ExecReload= /bin/kill -HUP $MAINPID
 ExecStop = /bin/kill -s TERM $MAINPID
 Environment=HOME={{ galaxy_root }} VIRTUAL_ENV={{ galaxy_venv_dir }} PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin DOCUTILSCONFIG='' PYTHONPATH={{ galaxy_server_dir }}/lib:{{ galaxy_dynamic_job_rules_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} {{ galaxy_systemd_gunicorn_env }}


### PR DESCRIPTION
Refer issue: https://github.com/usegalaxy-eu/ansible-galaxy-systemd/issues/13

The following variables can be added to the respective playbooks (group_vars). The default is set to 0.
1. `galaxy_systemd_gunicorn_max_requests`
2. `galaxy_systemd_gunicorn_max_requests_jitter`