### PR TITLE
Added autofs.service dependency to Galaxy Celery unit files

### DIFF
--- a/templates/galaxy-celery-beat.service.j2
+++ b/templates/galaxy-celery-beat.service.j2
@@ -2,6 +2,7 @@
 Description=Galaxy Celery
 After=network.target
 After=time-sync.target
+After=autofs.service
 
 [Service]
 UMask=022

--- a/templates/galaxy-celery-external@.service.j2
+++ b/templates/galaxy-celery-external@.service.j2
@@ -2,6 +2,7 @@
 Description=Galaxy Celery
 After=network.target
 After=time-sync.target
+After=autofs.service
 
 [Service]
 UMask=022

--- a/templates/galaxy-celery-internal@.service.j2
+++ b/templates/galaxy-celery-internal@.service.j2
@@ -2,6 +2,7 @@
 Description=Galaxy Celery
 After=network.target
 After=time-sync.target
+After=autofs.service
 
 [Service]
 UMask=022


### PR DESCRIPTION
Manuel has created a ping cycle script that pings the hypervisors, and if they do not respond, those hypervisors are considered "stuck", and then his script automatically reboots the server. As a result, when the celery VM gets rebooted, it looks for its files in the NFS share, and to make sure that the Celery service does not fail to start, this PR adds the `autofs.service` as a dependency. This failure behavior was observed in the ESG instance and the EU during the hypervisor image update on the day of the recent climate strike. 